### PR TITLE
Draft: Explore automatic `Channel` reconnection

### DIFF
--- a/Sources/DNSClient/DNSDecoder.swift
+++ b/Sources/DNSClient/DNSDecoder.swift
@@ -14,12 +14,15 @@ final class EnvelopeInboundChannel: ChannelInboundHandler {
 
 final class DNSDecoder: ChannelInboundHandler {
     let group: EventLoopGroup
-    var messageCache = [UInt16: SentQuery]()
     var clients = [ObjectIdentifier: DNSClient]()
+    var messageCache: MessageCache
+    
     weak var mainClient: DNSClient?
 
-    init(group: EventLoopGroup) {
+    init(group: EventLoopGroup, client: DNSClient) {
         self.group = group
+        self.mainClient = client
+        self.messageCache = client.messageCache
     }
 
     public typealias InboundIn = ByteBuffer
@@ -27,69 +30,82 @@ final class DNSDecoder: ChannelInboundHandler {
     
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let envelope = self.unwrapInboundIn(data)
-        var buffer = envelope
+        let readPromise = context.eventLoop.makePromise(of: Void.self)
 
-        guard let header = buffer.readHeader() else {
-            context.fireErrorCaught(ProtocolError())
-            return
+        // Any failure thrown from the task passed to completeWithTask
+        // will be propagated to the context
+        readPromise.futureResult.whenFailure { error in
+            context.fireErrorCaught(error)
         }
 
-        var questions = [QuestionSection]()
+        readPromise.completeWithTask {
+            var buffer = envelope
 
-        for _ in 0..<header.questionCount {
-            guard let question = buffer.readQuestion() else {
-                context.fireErrorCaught(ProtocolError())
-                return
+            guard let header = buffer.readHeader() else {
+                throw ProtocolError()
             }
 
-            questions.append(question)
-        }
+            var questions = [QuestionSection]()
 
-        func resourceRecords(count: UInt16) throws -> [Record] {
-            var records = [Record]()
-
-            for _ in 0..<count {
-                guard let record = buffer.readRecord() else {
+            for _ in 0..<header.questionCount {
+                guard let question = buffer.readQuestion() else {
                     throw ProtocolError()
                 }
 
-                records.append(record)
+                questions.append(question)
             }
 
-            return records
-        }
+            func resourceRecords(count: UInt16) throws -> [Record] {
+                var records = [Record]()
 
-        do {
-            let answers = try resourceRecords(count: header.answerCount)
-            let authorities = try resourceRecords(count: header.authorityCount)
-            let additionalData = try resourceRecords(count: header.additionalRecordCount)
-            
-            let message = Message(
-                header: header,
-                questions: questions,
-                answers: answers,
-                authorities: authorities,
-                additionalData: additionalData
-            )
+                for _ in 0..<count {
+                    guard let record = buffer.readRecord() else {
+                        throw ProtocolError()
+                    }
 
-            guard let query = messageCache[header.id] else {
-                throw UnknownQuery()
+                    records.append(record)
+                }
+
+                return records
             }
 
-            query.promise.succeed(message)
-            messageCache[header.id] = nil
-        } catch {
-            messageCache[header.id]?.promise.fail(error)
-            messageCache[header.id] = nil
-            context.fireErrorCaught(error)
+            do {
+                let answers = try resourceRecords(count: header.answerCount)
+                let authorities = try resourceRecords(count: header.authorityCount)
+                let additionalData = try resourceRecords(count: header.additionalRecordCount)
+
+                let message = Message(
+                    header: header,
+                    questions: questions,
+                    answers: answers,
+                    authorities: authorities,
+                    additionalData: additionalData
+                )
+
+                guard let query = await self.messageCache.queryForID(header.id) else {
+                    throw UnknownQuery()
+                }
+
+                query.promise.succeed(message)
+                await self.messageCache.removeQueryForID(header.id)
+            } catch {
+                await self.messageCache.queryForID(header.id)?.promise.fail(error)
+                await self.messageCache.removeQueryForID(header.id)
+                throw error
+            }
         }
+        
     }
 
     func errorCaught(context ctx: ChannelHandlerContext, error: Error) {
+        fatalError("Unimplemented")
+        // TODO: Check what to do here
+        /*
         for query in self.messageCache.values {
             query.promise.fail(error)
         }
 
         messageCache = [:]
+        */
     }
 }

--- a/Sources/DNSClient/GuaranteedValue.swift
+++ b/Sources/DNSClient/GuaranteedValue.swift
@@ -1,0 +1,118 @@
+/// This actor provides a value that guarantees to respect the specified precondition.
+///
+/// At first call the value is generated using the provided generator, then the precondition is checked
+/// and if it is not satisfied the value is regenerated up to the specified number of times.
+/// The generation count is reset after each successful valid value generation.
+/// If the specified number of times is exceeded, the actor will throw an error, either a generic error
+/// if no error was thrown by the generator or the precondition, or the specific error that was thrown.
+/// It is possible to specify a retry delay between each attempt.
+actor GuaranteedAsyncValue<Value, Context> {
+    private init(
+        maxRetries: Int = 1,
+        retryDelayNanoseconds: UInt64 = 0,
+        generator: @escaping (Context) async throws -> Value,
+        precondition: @escaping (Value, Context) async throws -> Bool,
+        _ _: ()
+    ) { 
+        self.maxRetries = maxRetries
+        self.retryDelayNanoseconds = retryDelayNanoseconds
+        self.precondition = precondition
+        self.generator = generator
+        var streamContinuation: AsyncStream<(CheckedContinuation<Value, Error>, Context)>.Continuation! = nil
+        self.continuationStream = AsyncStream<(CheckedContinuation<Value, Error>, Context)> { streamContinuation = $0 }
+        self.streamContinuation = streamContinuation
+    }
+
+    convenience init(
+        maxRetries: Int = 1,
+        retryDelayNanoseconds: UInt64 = 0,
+        generator: @escaping (Context) async throws -> Value,
+        precondition: @escaping (Value, Context) async throws -> Bool
+    ) {
+        self.init(
+            maxRetries: maxRetries,
+            retryDelayNanoseconds: retryDelayNanoseconds,
+            generator: generator,
+            precondition: precondition, ()
+        )
+
+        Task {
+            for await (continuation, context) in continuationStream {
+                do {
+                    continuation.resume(returning: try await self.getGuaranteedValue(context: context))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// The last valid value computed by the generator, nil if the generator has not yet been called.
+    private var currentValue: Value?
+
+    /// The generator is called when the value is requested, it should return a new value but can
+    /// throw an error if it is unable to compute the value. Errors thrown cause a retry.
+    private var generator: (Context) async throws -> Value
+
+    /// The precondition is called with the value before it is used, it should return true if the
+    /// value is valid, false or a specific error if it is not. If the precondition fails it
+    /// causes a retry.
+    private var precondition: (Value, Context) async throws -> Bool
+    let streamContinuation: AsyncStream<(CheckedContinuation<Value, Error>, Context)>.Continuation
+    private let continuationStream: AsyncStream<(CheckedContinuation<Value, Error>, Context)>
+    let maxRetries: Int
+    let retryDelayNanoseconds: UInt64
+
+    struct UnableToGenerate: Error {}
+
+    func getValue(context: Context) async throws -> Value {
+        try await withCheckedThrowingContinuation {
+            self.streamContinuation.yield(($0, context))
+        }
+    }
+
+    private func getGuaranteedValue(context: Context) async throws -> Value {
+        var lastError: Error
+        var retryCount = 0
+        repeat {
+            // We initialize lastError to the default error value, it will be overwritten if anything
+            // throws a more specific error before we get to the end of the loop.
+            lastError = UnableToGenerate()
+            if retryCount > 0 {
+                // If we are about to retry, wait for the specified delay.
+                try await Task.sleep(nanoseconds: retryDelayNanoseconds)
+            }
+            do {
+                // Get the value from the generator or the cached value if it is available.
+                let value = try await rawGenerateValue(context: context)
+                if try await precondition(value, context) {
+                    currentValue = value
+                    return value
+                } else {
+                    // Failed, so the cached value is no longer valid.
+                    currentValue = nil
+                }
+            } catch {
+                // Failed, so the cached value is no longer valid.
+                currentValue = nil
+                if error is CancellationError {
+                    // If the task was cancelled, we throw as soon as possible.
+                    throw error
+                } else {
+                    lastError = error
+                }
+            }
+            retryCount += 1
+        } while retryCount <= maxRetries
+        throw lastError
+    }
+
+    private func rawGenerateValue(context: Context) async throws -> Value {
+        if let value = currentValue {
+            return value
+        } else {
+            return try await generator(context)
+        }
+    }
+
+}

--- a/Sources/DNSClient/MessageCache.swift
+++ b/Sources/DNSClient/MessageCache.swift
@@ -1,0 +1,22 @@
+actor MessageCache {
+    private var messageCache = [UInt16: SentQuery]()
+
+    func queryForID(_ id: UInt16) -> SentQuery? {
+        return messageCache[id]
+    }
+
+    func addQuery(_ query: SentQuery) {
+        messageCache[query.message.header.id] = query
+    }
+
+    func removeQueryForID(_ id: UInt16) {
+        messageCache[id] = nil
+    }
+
+    func failReset() {
+        for query in messageCache.values {
+            query.promise.fail(CancelError())
+        }
+        messageCache.removeAll()
+    }
+}


### PR DESCRIPTION
This PR adds a `GuaranteedAsyncValue` actor whose main goal is to check that the value it holds respects a certain precondition and asynchronously regenerate it if it doesn't.
The other changes are here mostly to use this new type, for instance using the async NIO functions etc...
This is still a work in progress, for instance some events such as channel errors aren't handled yet.

These changes enable making sure the channel you are getting is opened at the moment it is provided to you, I suppose this could be combined with an actual retry logic so that when a request fails because of a connection issue you can just repeat it.
