### PR TITLE
Fix PTR on Linux

### DIFF
--- a/Tests/DNSClientTests/DNSUDPClientTests.swift
+++ b/Tests/DNSClientTests/DNSUDPClientTests.swift
@@ -137,7 +137,6 @@ final class DNSUDPClientTests: XCTestCase {
     //     }
     // }
     
-    #if !os(Linux)
     // 4.4.8.8.in-addr.arpa domain points to dns.google.
     func testipv4InverseAddress() throws {
         let answers = try dnsClient.ipv4InverseAddress("8.8.4.4").wait()
@@ -171,7 +170,12 @@ final class DNSUDPClientTests: XCTestCase {
     
     func testipv6InverseAddressInvalidInput() throws {
         XCTAssertThrowsError(try dnsClient.ipv6InverseAddress(":::0").wait()) { error in
+            
+            #if os(Linux)
+            XCTAssertEqual(error.localizedDescription , "The operation could not be completed. (NIOCore.IOError error 1.)")
+            #else
             XCTAssertEqual(error.localizedDescription , "The operation couldn’t be completed. (NIOCore.IOError error 1.)")
+            #endif
         }
     }
     
@@ -182,5 +186,4 @@ final class DNSUDPClientTests: XCTestCase {
         
         XCTAssertEqual(domainname.description, "PTRRecord: dns.google")
     }
-    #endif
 }


### PR DESCRIPTION
root@e4f2a699a6e6:/src/Sources/DNSClient# swift --version Swift version 5.8.1 (swift-5.8.1-RELEASE)
Target: aarch64-unknown-linux-gnu

Test Case 'DNSUDPClientTests.testipv4InverseAddress' started at 2023-08-30 02:00:11.277 Test Case 'DNSUDPClientTests.testipv4InverseAddress' passed (0.015 seconds) Test Case 'DNSUDPClientTests.testipv4InverseAddressMultipleResponses' started at 2023-08-30 02:00:11.292 Test Case 'DNSUDPClientTests.testipv4InverseAddressMultipleResponses' passed (0.006 seconds) Test Case 'DNSUDPClientTests.testipv6InverseAddress' started at 2023-08-30 02:00:11.298 Test Case 'DNSUDPClientTests.testipv6InverseAddress' passed (0.029 seconds) Test Case 'DNSUDPClientTests.testipv6InverseAddressInvalidInput' started at 2023-08-30 02:00:11.327 Test Case 'DNSUDPClientTests.testipv6InverseAddressInvalidInput' passed (0.012 seconds) Test Suite 'DNSUDPClientTests' passed at 2023-08-30 02:00:11.340
	 Executed 14 tests, with 0 failures (0 unexpected) in 0.158 (0.158) seconds
Test Suite 'debug.xctest' passed at 2023-08-30 02:00:11.340
	 Executed 27 tests, with 0 failures (0 unexpected) in 0.561 (0.561) seconds
Test Suite 'All tests' passed at 2023-08-30 02:00:11.340
	 Executed 27 tests, with 0 failures (0 unexpected) in 0.561 (0.561) seconds