### PR TITLE
Fix an issue with ipv6 struct in6_addr that is not the same in Glibc and Musl

### DIFF
--- a/Sources/DNSClient/PTR.swift
+++ b/Sources/DNSClient/PTR.swift
@@ -77,7 +77,7 @@ extension DNSClient {
             throw IOError(errnoCode: errno, reason: #function)
         }
         
-        #if os(Linux)
+        #if canImport(Glibc)
         let inAddrArpaDomain = String(format: "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
                       ipv6Addr.__in6_u.__u6_addr8.0,
                       ipv6Addr.__in6_u.__u6_addr8.1,
@@ -100,6 +100,28 @@ extension DNSClient {
          .joined(separator: ".")
          .appending(".ip6.arpa.")
         
+        #elseif canImport(Musl)
+        let inAddrArpaDomain = String(format: "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+                      ipv6Addr.__in6_union.__s6_addr.0,
+                      ipv6Addr.__in6_union.__s6_addr.1,
+                      ipv6Addr.__in6_union.__s6_addr.2,
+                      ipv6Addr.__in6_union.__s6_addr.3,
+                      ipv6Addr.__in6_union.__s6_addr.4,
+                      ipv6Addr.__in6_union.__s6_addr.5,
+                      ipv6Addr.__in6_union.__s6_addr.6,
+                      ipv6Addr.__in6_union.__s6_addr.7,
+                      ipv6Addr.__in6_union.__s6_addr.8,
+                      ipv6Addr.__in6_union.__s6_addr.9,
+                      ipv6Addr.__in6_union.__s6_addr.10,
+                      ipv6Addr.__in6_union.__s6_addr.11,
+                      ipv6Addr.__in6_union.__s6_addr.12,
+                      ipv6Addr.__in6_union.__s6_addr.13,
+                      ipv6Addr.__in6_union.__s6_addr.14,
+                      ipv6Addr.__in6_union.__s6_addr.15
+        ).reversed()
+         .map { "\($0)" }
+         .joined(separator: ".")
+         .appending(".ip6.arpa.")
         #else
         let inAddrArpaDomain = String(format: "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
                       ipv6Addr.__u6_addr.__u6_addr8.0,


### PR DESCRIPTION
Pull request to fix issue #31 

The issue is due to differences between Glibc and Musl.
For static cross-compilation for linux, Apple use Musl instead of Glibc https://www.swift.org/documentation/articles/static-linux-getting-started.html

So, the code for linux in PTR.swift and DNSClient+Query.swift should in fact be different for Glibc and Musl using
#if canImport(Glibc)
...
#elseif canImport(Musl)
...
#else

Then, the issue is related to differences in header netinet/in.h related to ipv6.
Here are the links to both headers
https://github.com/lattera/glibc/blob/master/inet/netinet/in.h
https://github.com/cloudius-systems/musl/blob/master/include/netinet/in.h

By looking to the differences in the struct in6_addr, I was able to propose this fix.

Regards

Vincent